### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Paste
+"SET SUNO_USE_SMALL_MODELS=True"
+at the top of the run.bat if you run into CUDA out of memory errors
+
 [One click installer](https://github.com/Fictiverse/bark/releases) + WebUI
 ![image](https://user-images.githubusercontent.com/111762798/233760231-50eb145a-2d0d-4623-93b6-00477ee83ad5.png)
 


### PR DESCRIPTION
Alternatively, there could be a second run-small.bat or an option to use the small models.

For reference, with default settings 8gb of VRAM is guaranteed to fail; meanwhile with small models 4gb VRAM has been reported to work.